### PR TITLE
fix(build): update exports and package.json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+export * from './src/index';
+export { Query as QueryBuilder } from './src/builder';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@types/elasticsearch-dsl",
+  "name": "elasticsearch-dsl",
   "version": "1.0.0",
   "description": "Types for Elasticsearch Query DSL",
   "main": "index.js",
@@ -11,6 +11,10 @@
     "@types/jasmine": "^2.8.6",
     "elasticsearch": "^14.1.0",
     "jasmine": "^2.9.0"
+  },
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/ptpt/elasticsearch-dsl.git"
   },
   "scripts": {
     "test": "jasmine dist/tests.js"


### PR DESCRIPTION
This PR contains following changes:
- update `repository` property in `package.json`, so it's possible to install the package from GitHub
- export `builder.ts` contents under `QueryBuilder` namespace
- export all the `src/index.d.ts` in the `/index.ts` file directly
- update the package names, so it's not scoped under `@types`